### PR TITLE
🔀 :: (#31) - add_mindway_bottom_navigation_bar

### DIFF
--- a/presentation/src/main/java/com/chobo/presentation/view/component/bottom_navigation_bar/MindWayNavBar.kt
+++ b/presentation/src/main/java/com/chobo/presentation/view/component/bottom_navigation_bar/MindWayNavBar.kt
@@ -1,0 +1,62 @@
+package com.chobo.presentation.view.component.bottom_navigation_bar
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.chobo.presentation.view.theme.MindWayAndroidTheme
+
+@Composable
+fun MindWayNavBar(
+    modifier: Modifier = Modifier
+) {
+    val itemList = listOf(
+        MindWayNavBarItemType.HOME,
+        MindWayNavBarItemType.EVENT,
+        MindWayNavBarItemType.BOOKS,
+        MindWayNavBarItemType.MY
+    )
+
+    MindWayAndroidTheme { colors, _ ->
+        Row(
+            modifier = modifier
+                .fillMaxWidth()
+                .background(colors.WHITE)
+                .padding(
+                    start = 28.dp,
+                    end = 28.dp,
+                    top = 8.dp,
+                    bottom = 32.dp
+                ),
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            repeat(itemList.size) {
+                MindWayNavBarItem(
+                    modifier = modifier
+                        .clickable(
+                            interactionSource = MutableInteractionSource(),
+                            indication = null,
+                            onClick = {
+
+                            }
+                        ),
+                    type = itemList[it]
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+fun MindWayNavBarPre() {
+    MindWayNavBar()
+}

--- a/presentation/src/main/java/com/chobo/presentation/view/component/bottom_navigation_bar/MindWayNavBarItem.kt
+++ b/presentation/src/main/java/com/chobo/presentation/view/component/bottom_navigation_bar/MindWayNavBarItem.kt
@@ -1,0 +1,91 @@
+package com.chobo.presentation.view.component.bottom_navigation_bar
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.chobo.presentation.R
+import com.chobo.presentation.view.component.icon.BookIcon
+import com.chobo.presentation.view.component.icon.HeartIcon
+import com.chobo.presentation.view.component.icon.HomeIcon
+import com.chobo.presentation.view.component.icon.ProfileIcon
+import com.chobo.presentation.view.theme.MindWayAndroidTheme
+
+@Composable
+fun MindWayNavBarItem(
+    modifier: Modifier = Modifier,
+    type: MindWayNavBarItemType
+) {
+    MindWayAndroidTheme { _, typography ->
+        when(type) {
+            MindWayNavBarItemType.HOME -> {
+                Column(
+                    verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    HomeIcon(modifier = modifier)
+                    Spacer(modifier = modifier.height(4.dp))
+                    Text(
+                        text = stringResource(id = R.string.home),
+                        style = typography.labelLarge,
+                        fontWeight = FontWeight.Normal,
+                        fontSize = 14.sp
+                    )
+                }
+            }
+            MindWayNavBarItemType.EVENT -> {
+                Column(
+                    verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    HeartIcon(modifier = modifier)
+                    Spacer(modifier = modifier.height(4.dp))
+                    Text(
+                        text = stringResource(id = R.string.event),
+                        style = typography.labelLarge,
+                        fontWeight = FontWeight.Normal,
+                        fontSize = 14.sp
+                    )
+                }
+            }
+            MindWayNavBarItemType.BOOKS -> {
+                Column(
+                    verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    BookIcon(modifier = modifier)
+                    Spacer(modifier = modifier.height(4.dp))
+                    Text(
+                        text = stringResource(id = R.string.books),
+                        style = typography.labelLarge,
+                        fontWeight = FontWeight.Normal,
+                        fontSize = 14.sp
+                    )
+                }
+            }
+            MindWayNavBarItemType.MY -> {
+                Column(
+                    verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    ProfileIcon(modifier = modifier)
+                    Spacer(modifier = modifier.height(4.dp))
+                    Text(
+                        text = stringResource(id = R.string.my),
+                        style = typography.labelLarge,
+                        fontWeight = FontWeight.Normal,
+                        fontSize = 14.sp
+                    )
+                }
+            }
+        }
+    }
+}

--- a/presentation/src/main/java/com/chobo/presentation/view/component/bottom_navigation_bar/MindWayNavBarItemType.kt
+++ b/presentation/src/main/java/com/chobo/presentation/view/component/bottom_navigation_bar/MindWayNavBarItemType.kt
@@ -1,0 +1,5 @@
+package com.chobo.presentation.view.component.bottom_navigation_bar
+
+enum class MindWayNavBarItemType {
+    HOME, EVENT, BOOKS, MY
+}


### PR DESCRIPTION
## 📌 개요
- 마인드웨이 바텀 네비게이션바 퍼블리싱

## 📸 구현 화면
- <img width="342" alt="스크린샷 2024-04-03 오후 2 47 48" src="https://github.com/Team-MindWay/Mindway-v2-Android/assets/108732289/620ffa79-890f-46d1-b82d-506a3b9eac06">
