### PR TITLE
🔀 :: (#152) - home_screen_performance_improve

### DIFF
--- a/presentation/src/main/java/com/chobo/presentation/view/main/component/HomeGoalReadingChart.kt
+++ b/presentation/src/main/java/com/chobo/presentation/view/main/component/HomeGoalReadingChart.kt
@@ -37,13 +37,12 @@ data class GoalReadingGraphData(
 @Composable
 fun HomeGoalReadingChart(
     modifier: Modifier,
-    isHasData: Boolean,
     readNumberList: List<GoalReadingGraphData> = listOf(),
     onClick: () -> Unit,
     goalBookRead: StateFlow<Int>,
 ) {
     MindWayAndroidTheme { colors, typography ->
-        if (isHasData) {
+        if (readNumberList.isNotEmpty()) {
             Column(
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.Top),

--- a/presentation/src/main/java/com/chobo/presentation/view/main/component/HomeGoalReadingChart.kt
+++ b/presentation/src/main/java/com/chobo/presentation/view/main/component/HomeGoalReadingChart.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
@@ -24,8 +23,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.chobo.presentation.view.component.icon.ChevronRightIcon
 import com.chobo.presentation.view.theme.MindWayAndroidTheme
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 
 data class GoalReadingGraphData(
     val numBooksRead: Int,
@@ -83,7 +80,7 @@ fun HomeGoalReadingChart(
                     }
                     GoalReadingIndicator(
                         numBooksRead = readNumberList.sumOf { it.numBooksRead },
-                        goalBookRead = goalBookRead.collectAsState().value,
+                        goalBookRead = goalBookRead,
                         modifier = Modifier
                             .fillMaxWidth()
                             .fillMaxHeight(0.1840f)
@@ -114,7 +111,6 @@ fun HomeGoalReadingChart(
                 verticalArrangement = Arrangement.SpaceBetween,
                 horizontalAlignment = Alignment.CenterHorizontally,
                 modifier = modifier
-                    .padding(all = 24.dp)
                     .shadow(
                         elevation = 20.dp,
                         spotColor = colors.GRAY400,
@@ -124,13 +120,12 @@ fun HomeGoalReadingChart(
                         color = colors.WHITE,
                         shape = RoundedCornerShape(size = 8.dp)
                     )
+                    .padding(all = 24.dp)
             ) {
                 Row(
-                    horizontalArrangement = Arrangement.spacedBy(
-                        12.dp,
-                        Alignment.CenterHorizontally
-                    ),
+                    horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.Top,
+                    modifier = Modifier.fillMaxWidth()
                 ) {
                     Text(
                         text = "목표 독서량",

--- a/presentation/src/main/java/com/chobo/presentation/view/main/component/HomeGoalReadingChart.kt
+++ b/presentation/src/main/java/com/chobo/presentation/view/main/component/HomeGoalReadingChart.kt
@@ -36,7 +36,7 @@ data class GoalReadingGraphData(
 
 @Composable
 fun HomeGoalReadingChart(
-    modifier: Modifier,
+    modifier: Modifier = Modifier,
     readNumberList: List<GoalReadingGraphData> = listOf(),
     onClick: () -> Unit,
     goalBookRead: StateFlow<Int>,

--- a/presentation/src/main/java/com/chobo/presentation/view/main/component/HomeGoalReadingChart.kt
+++ b/presentation/src/main/java/com/chobo/presentation/view/main/component/HomeGoalReadingChart.kt
@@ -49,8 +49,8 @@ fun HomeGoalReadingChart(
                 modifier = modifier
                     .shadow(
                         elevation = 20.dp,
-                        spotColor = colors.GRAY400,
-                        ambientColor = colors.GRAY400
+                        spotColor = colors.CardShadow,
+                        ambientColor = colors.CardShadow
                     )
                     .background(
                         color = colors.WHITE,

--- a/presentation/src/main/java/com/chobo/presentation/view/main/component/HomeGoalReadingChart.kt
+++ b/presentation/src/main/java/com/chobo/presentation/view/main/component/HomeGoalReadingChart.kt
@@ -37,9 +37,9 @@ data class GoalReadingGraphData(
 @Composable
 fun HomeGoalReadingChart(
     modifier: Modifier = Modifier,
+    goalBookRead: Int,
     readNumberList: List<GoalReadingGraphData> = listOf(),
     onClick: () -> Unit,
-    goalBookRead: StateFlow<Int>,
 ) {
     MindWayAndroidTheme { colors, typography ->
         if (readNumberList.isNotEmpty()) {
@@ -157,13 +157,11 @@ fun HomeGoalReadingChart(
 @Preview
 @Composable
 fun HomeGoalReadingChartPreview() {
-    val _goalBookRead = MutableStateFlow(15)
 
     HomeGoalReadingChart(
         modifier = Modifier
             .width(312.dp)
             .height(211.dp),
-        isHasData = true,
         readNumberList = listOf(
             GoalReadingGraphData(2, 3, false, "일"),
             GoalReadingGraphData(3, 3, false, "일"),
@@ -174,6 +172,6 @@ fun HomeGoalReadingChartPreview() {
             GoalReadingGraphData(2, 3, false, "일"),
         ),
         onClick = { },
-        goalBookRead =_goalBookRead
+        goalBookRead = 14
     )
 }

--- a/presentation/src/main/java/com/chobo/presentation/view/main/component/HomeNoticeCard.kt
+++ b/presentation/src/main/java/com/chobo/presentation/view/main/component/HomeNoticeCard.kt
@@ -48,11 +48,7 @@ fun HomeNoticeCard(
                     color = colors.GRAY100,
                     shape = RoundedCornerShape(size = 8.dp)
                 )
-                .fillMaxWidth()
-                .padding(
-                    horizontal = 12.dp,
-                    vertical = 18.5.dp
-                )
+                .padding(horizontal = 12.dp,)
         ) {
             Image(
                 painter = painterResource(id = R.drawable.ic__notice),
@@ -60,7 +56,7 @@ fun HomeNoticeCard(
                 contentScale = ContentScale.None,
             )
             Column(
-                verticalArrangement = Arrangement.spacedBy(0.dp, Alignment.Top),
+                verticalArrangement = Arrangement.SpaceBetween,
                 horizontalAlignment = Alignment.Start,
             ) {
                 Text(

--- a/presentation/src/main/java/com/chobo/presentation/view/main/component/HomeReadersOfTheMonthChart.kt
+++ b/presentation/src/main/java/com/chobo/presentation/view/main/component/HomeReadersOfTheMonthChart.kt
@@ -77,8 +77,8 @@ fun HomeReadersOfTheMonthChart(
                 modifier = modifier
                     .shadow(
                         elevation = 20.dp,
-                        spotColor = colors.GRAY400,
-                        ambientColor = colors.GRAY400
+                        spotColor = colors.CardShadow,
+                        ambientColor = colors.CardShadow,
                     )
                     .background(
                         color = colors.WHITE,

--- a/presentation/src/main/java/com/chobo/presentation/view/main/component/HomeReadersOfTheMonthChart.kt
+++ b/presentation/src/main/java/com/chobo/presentation/view/main/component/HomeReadersOfTheMonthChart.kt
@@ -25,11 +25,10 @@ data class BookKingOfTheMonthData(val name: String, val numOfBooks: Int)
 @Composable
 fun HomeReadersOfTheMonthChart(
     modifier: Modifier = Modifier,
-    isHasData: Boolean,
     bookKingOfTheMonthData: List<BookKingOfTheMonthData>
 ) {
     MindWayAndroidTheme { colors, typography ->
-        if (isHasData) {
+        if (bookKingOfTheMonthData.isNotEmpty()) {
             Column(
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.spacedBy(20.dp, Alignment.Top),

--- a/presentation/src/main/java/com/chobo/presentation/view/main/component/HomeReadersOfTheMonthChart.kt
+++ b/presentation/src/main/java/com/chobo/presentation/view/main/component/HomeReadersOfTheMonthChart.kt
@@ -84,12 +84,14 @@ fun HomeReadersOfTheMonthChart(
                         color = colors.WHITE,
                         shape = RoundedCornerShape(size = 8.dp)
                     )
+                    .padding(all = 24.dp)
             ) {
                 Text(
                     text = "이달의 독서왕",
                     style = typography.bodyMedium,
                     fontWeight = FontWeight.SemiBold,
                     color = colors.Black,
+                    modifier = Modifier.fillMaxWidth()
                 )
                 Text(
                     text = "아직 이달의 독서왕이 없습니다.",
@@ -107,7 +109,6 @@ fun HomeReadersOfTheMonthChart(
 @Composable
 fun HomeReadersOfTheMonthChartPreview() {
     HomeReadersOfTheMonthChart(
-        isHasData = true,
         modifier = Modifier
             .width(312.dp),
         bookKingOfTheMonthData = listOf(

--- a/presentation/src/main/java/com/chobo/presentation/view/main/component/HomeReadersOfTheMonthChart.kt
+++ b/presentation/src/main/java/com/chobo/presentation/view/main/component/HomeReadersOfTheMonthChart.kt
@@ -74,10 +74,7 @@ fun HomeReadersOfTheMonthChart(
             Column(
                 verticalArrangement = Arrangement.SpaceBetween,
                 horizontalAlignment = Alignment.CenterHorizontally,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(239.dp)
-                    .padding(all = 24.dp)
+                modifier = modifier
                     .shadow(
                         elevation = 20.dp,
                         spotColor = colors.GRAY400,

--- a/presentation/src/main/java/com/chobo/presentation/view/main/screen/HomeScreen.kt
+++ b/presentation/src/main/java/com/chobo/presentation/view/main/screen/HomeScreen.kt
@@ -23,6 +23,7 @@ import com.chobo.presentation.viewModel.HomeViewModel
 
 @Composable
 fun HomeScreen(
+    modifier: Modifier = Modifier,
     homeViewModel: HomeViewModel = viewModel(),
     navigateToGoalReading: () -> Unit,
     navigateToDetailEvent: () -> Unit,
@@ -36,7 +37,7 @@ fun HomeScreen(
         Column(
             verticalArrangement = Arrangement.spacedBy(20.dp, Alignment.Top),
             horizontalAlignment = Alignment.CenterHorizontally,
-            modifier = Modifier
+            modifier = modifier
                 .background(color = colors.WHITE)
                 .fillMaxSize()
                 .padding(horizontal = 24.dp)

--- a/presentation/src/main/java/com/chobo/presentation/view/main/screen/HomeScreen.kt
+++ b/presentation/src/main/java/com/chobo/presentation/view/main/screen/HomeScreen.kt
@@ -30,10 +30,11 @@ fun HomeScreen(
 ) {
     val titleTextState by homeViewModel.titleTextState.collectAsState()
     val contentTextState by homeViewModel.contentTextState.collectAsState()
+    val goalBookRead by homeViewModel.goalBookRead.collectAsState()
     val readingGoalGraphDataList by homeViewModel.goalReadingGraphDataList.collectAsState()
     val bookKingOfTheMonthDataList by homeViewModel.bookKingOfTheMonthDataList.collectAsState()
 
-    MindWayAndroidTheme { colors, typography ->
+    MindWayAndroidTheme { colors, _ ->
         Column(
             verticalArrangement = Arrangement.spacedBy(20.dp, Alignment.Top),
             horizontalAlignment = Alignment.CenterHorizontally,
@@ -45,20 +46,24 @@ fun HomeScreen(
             HomeNoticeCard(
                 titleText = titleTextState,
                 content = contentTextState,
-                onClick = navigateToDetailEvent
+                onClick = navigateToDetailEvent,
+                modifier = Modifier
+                    .height(100.dp)
+                    .fillMaxWidth(),
             )
             HomeGoalReadingChart(
+                readNumberList = readingGoalGraphDataList,
+                onClick = navigateToGoalReading,
+                goalBookRead = goalBookRead,
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(211.dp),
-                isHasData = true,
-                readNumberList = readingGoalGraphDataList,
-                onClick = navigateToGoalReading,
-                goalBookRead = homeViewModel.goalBookRead
             )
             HomeReadersOfTheMonthChart(
-                isHasData = true,
-                bookKingOfTheMonthData = bookKingOfTheMonthDataList
+                bookKingOfTheMonthData = bookKingOfTheMonthDataList,
+                modifier = Modifier
+                    .height(239.dp)
+                    .fillMaxWidth(),
             )
         }
     }

--- a/presentation/src/main/java/com/chobo/presentation/viewModel/HomeViewModel.kt
+++ b/presentation/src/main/java/com/chobo/presentation/viewModel/HomeViewModel.kt
@@ -27,13 +27,7 @@ class HomeViewModel @Inject constructor() : ViewModel() {
 
     private val _contentTextState = MutableStateFlow("")
     val contentTextState: StateFlow<String> = _contentTextState.asStateFlow()
-    fun homeNoticeCardOnClick() {
 
-    }
-
-    fun homeGoalReadingChartOnClick(index: Int) {
-
-    }
     init {
         _goalBookRead.value = 15
         _goalReadingGraphDataList.value = listOf(


### PR DESCRIPTION
## 📌 개요
- 한 일을 간단하게 적어주세요.

home_screen의 불필요한 코드를 정리하고 가독성을 향상시켰습니다

## 📸 구현 화면
- 스크린샷이 필요하다면 첨부해주세요.

```kt
 MindWayAndroidTheme { colors, typography ->
        Column(
            verticalArrangement = Arrangement.spacedBy(20.dp, Alignment.Top),
            horizontalAlignment = Alignment.CenterHorizontally,
            modifier = Modifier
                .background(color = colors.WHITE)
                .fillMaxSize()
                .padding(horizontal = 24.dp)
        ) {
            HomeNoticeCard(
                titleText = titleTextState,
                content = contentTextState,
                onClick = navigateToDetailEvent
            )
            HomeGoalReadingChart(
                modifier = Modifier
                    .fillMaxWidth()
                    .height(211.dp),
                isHasData = true,
                readNumberList = readingGoalGraphDataList,
                onClick = navigateToGoalReading,
                goalBookRead = homeViewModel.goalBookRead
            )
            HomeReadersOfTheMonthChart(
                isHasData = true,
                bookKingOfTheMonthData = bookKingOfTheMonthDataList
            )
        }
    }
```

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
- 참고할 사항이 있다면 적어주세요.
