### PR TITLE
🔀 :: (#203) - mindwaytextfield_edit

### DIFF
--- a/presentation/src/main/java/com/chobo/presentation/view/component/textField/MindWayTextField.kt
+++ b/presentation/src/main/java/com/chobo/presentation/view/component/textField/MindWayTextField.kt
@@ -75,21 +75,20 @@ fun MindWayTextField(
                     }
                 }
             }
-            Box(
-                modifier = Modifier
-                    .border(
-                        width = 1.dp,
-                        color = if (lengthCheck || isError) colors.SYSTEM else colors.GRAY100,
-                        shape = RoundedCornerShape(size = 8.dp)
-                    )
-                    .background(
-                        color = colors.GRAY100,
-                        shape = RoundedCornerShape(size = 8.dp)
-                    )
-            ) {
-                LazyColumn {
-                    item {
-                        Box {
+            LazyColumn {
+                item {
+                    Box(
+                        modifier = Modifier
+                            .border(
+                                width = 1.dp,
+                                color = if (lengthCheck || isError) colors.SYSTEM else colors.GRAY100,
+                                shape = RoundedCornerShape(size = 8.dp)
+                            )
+                            .background(
+                                color = colors.GRAY100,
+                                shape = RoundedCornerShape(size = 8.dp)
+                            )
+                    ) {
                             BasicTextField(
                                 onValueChange = { newText ->
                                     if (lengthLimit != 0) {
@@ -109,51 +108,50 @@ fun MindWayTextField(
                                 cursorBrush = SolidColor(colors.MAIN),
                                 modifier = Modifier
                                     .fillMaxWidth()
-                                    .padding(15.dp),
                             )
-                            Row(
-                                verticalAlignment = Alignment.CenterVertically,
-                                horizontalArrangement = if (isTextRight) Arrangement.End else Arrangement.Start,
-                                modifier = Modifier
-                                    .padding(16.dp)
-                                    .fillMaxWidth()
-                            ) {
-                                if (isTextRight) {
-                                    Text(
-                                        text = placeholder,
-                                        style = typography.bodySmall,
-                                        fontWeight = FontWeight.Normal,
-                                        color = colors.GRAY400,
-                                    )
-                                } else if (textState.isEmpty()) {
-                                    Text(
-                                        text = placeholder,
-                                        style = typography.bodySmall,
-                                        fontWeight = FontWeight.Normal,
-                                        color = colors.GRAY400,
-                                    )
-                                }
+                        }
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = if (isTextRight) Arrangement.End else Arrangement.Start,
+                            modifier = Modifier
+                                .padding(16.dp)
+                                .fillMaxWidth()
+                        ) {
+                            if (isTextRight) {
+                                Text(
+                                    text = placeholder,
+                                    style = typography.bodySmall,
+                                    fontWeight = FontWeight.Normal,
+                                    color = colors.GRAY400,
+                                )
+                            } else if (textState.isEmpty()) {
+                                Text(
+                                    text = placeholder,
+                                    style = typography.bodySmall,
+                                    fontWeight = FontWeight.Normal,
+                                    color = colors.GRAY400,
+                                )
                             }
                         }
                     }
                 }
             }
-            if (lengthCheck) {
-                Text(
-                    text = overflowErrorMessage,
-                    style = typography.labelLarge,
-                    fontWeight = FontWeight.Normal,
-                    color = colors.SYSTEM
-                )
-            }
-            if (isError) {
-                Text(
-                    text = emptyErrorMessage,
-                    style = typography.labelLarge,
-                    fontWeight = FontWeight.Normal,
-                    color = colors.SYSTEM
-                )
-            }
+        }
+        if (lengthCheck) {
+            Text(
+                text = overflowErrorMessage,
+                style = typography.labelLarge,
+                fontWeight = FontWeight.Normal,
+                color = colors.SYSTEM
+            )
+        }
+        if (isError) {
+            Text(
+                text = emptyErrorMessage,
+                style = typography.labelLarge,
+                fontWeight = FontWeight.Normal,
+                color = colors.SYSTEM
+            )
         }
     }
 }

--- a/presentation/src/main/java/com/chobo/presentation/view/component/textField/MindWayTextField.kt
+++ b/presentation/src/main/java/com/chobo/presentation/view/component/textField/MindWayTextField.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.SolidColor
@@ -37,7 +38,9 @@ fun MindWayTextField(
     lengthLimit: Int = 0,
     updateTextValue: (String) -> Unit,
 ) {
-    val lengthCheck = if (lengthLimit != 0) textState.length >= lengthLimit else false
+    val lengthCheck = remember {
+        if (lengthLimit != 0) textState.length >= lengthLimit else false
+    }
     MindWayAndroidTheme { colors, typography ->
         Column(
             verticalArrangement = Arrangement.spacedBy(4.dp, Alignment.Top),

--- a/presentation/src/main/java/com/chobo/presentation/view/component/textField/MindWayTextField.kt
+++ b/presentation/src/main/java/com/chobo/presentation/view/component/textField/MindWayTextField.kt
@@ -89,6 +89,21 @@ fun MindWayTextField(
                                 shape = RoundedCornerShape(size = 8.dp)
                             )
                     ) {
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(4.dp, Alignment.End),
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .then(
+                                    if (isTextRight) Modifier.padding(
+                                        top = 16.dp,
+                                        bottom = 16.dp,
+                                        start = 16.dp,
+                                        end = 34.dp
+                                    )
+                                    else Modifier.padding(16.dp)
+                                )
+                        ) {
                             BasicTextField(
                                 onValueChange = { newText ->
                                     if (lengthLimit != 0) {


### PR DESCRIPTION
## 📌 개요
- 한 일을 간단하게 적어주세요.

mindwaytextfield의 recompose를 줄이고 
불필요한 Box를 삭제 하고 
isTextRight = true일때 오른쪽 패딩 추가 하였습니다

## 📸 구현 화면
- 스크린샷이 필요하다면 첨부해주세요.

<img width="254" alt="스크린샷 2024-04-28 오후 6 00 11" src="https://github.com/Team-MindWay/Mindway-v2-Android/assets/118062596/cb569416-8050-45b3-8272-b1820ca4ad87">

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
- 참고할 사항이 있다면 적어주세요.
