### PR TITLE
🔀 :: (#205) - multipleeventscutter_performance_improve

### DIFF
--- a/presentation/src/main/java/com/chobo/presentation/view/component/multipleEventsCutterManager/clickableSingle.kt
+++ b/presentation/src/main/java/com/chobo/presentation/view/component/multipleEventsCutterManager/clickableSingle.kt
@@ -6,19 +6,17 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
-import androidx.compose.ui.platform.debugInspectorInfo
 
 @SuppressLint("ModifierFactoryUnreferencedReceiver")
 fun Modifier.clickableSingle(
     enabled: Boolean = true,
     onClick: () -> Unit
-): Modifier = composed {
-    multipleEventsCutter { manager ->
-        clickable(
-            enabled = enabled,
-            onClick = { manager.processEvent { onClick() } },
-            indication = null,
-            interactionSource = remember { MutableInteractionSource() }
-        )
-    }
+) = composed {
+    val multipleEventsCutter = remember { MultipleEventsCutter.get() }
+    Modifier.clickable(
+        enabled = enabled,
+        onClick = { multipleEventsCutter.processEvent { onClick() } },
+        indication = null,
+        interactionSource = remember { MutableInteractionSource() }
+    )
 }


### PR DESCRIPTION
## 📌 개요
- 한 일을 간단하게 적어주세요.

multipleeventscutter의 로직을 시스템의 시간을 이용하도록 변경 했습니다

## 📸 구현 화면
- 스크린샷이 필요하다면 첨부해주세요.

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
- 참고할 사항이 있다면 적어주세요.
