### PR TITLE
:twisted_rightwards_arrows: :: (#229) - Apply Design

### DIFF
--- a/presentation/src/main/java/com/chobo/presentation/view/book/component/BookRequestTopAppBar.kt
+++ b/presentation/src/main/java/com/chobo/presentation/view/book/component/BookRequestTopAppBar.kt
@@ -26,14 +26,6 @@ fun BookRequestTopAppBar(
             )
         },
         midText = stringResource(R.string.book_request),
-        endIcon = {
-            InfoIcon(
-                modifier = Modifier.clickable(
-                    interactionSource = MutableInteractionSource(),
-                    indication = null
-                ) { endIconOnClick() }
-            )
-        }
     )
 }
 @Preview(showBackground = true)


### PR DESCRIPTION
## 📌 개요
- BookAddScreen의 topbar의 endIcon을 삭제했습니다

## 📸 구현 화면
<img width="263" alt="image" src="https://github.com/Team-MindWay/Mindway-v2-Android/assets/132070179/d4f683e1-7870-409f-8b54-ba8d35d9318b">

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
- 참고할 사항이 있다면 적어주세요.
