### PR TITLE
🔀 :: (#367) - datasourceimpl의 반복되는 로직 개선

### DIFF
--- a/data/src/main/java/com/chobo/data/remote/datasource/auth/RemoteAuthDataSourceImpl.kt
+++ b/data/src/main/java/com/chobo/data/remote/datasource/auth/RemoteAuthDataSourceImpl.kt
@@ -5,17 +5,14 @@ import com.chobo.data.remote.dto.auth.request.GAuthLoginRequestBody
 import com.chobo.data.remote.dto.auth.response.GAuthLoginResponse
 import com.chobo.data.util.performApiRequest
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
 class RemoteAuthDataSourceImpl @Inject constructor(
     private val authService: AuthAPI
 ) : RemoteAuthDataSource {
-    override suspend fun GuauthLogin(body: GAuthLoginRequestBody): Flow<GAuthLoginResponse> = flow {
+    override suspend fun GuauthLogin(body: GAuthLoginRequestBody): Flow<GAuthLoginResponse> =
         performApiRequest { authService.gAuthLogin(body = body) }
-    }
 
-    override suspend fun GuathLogout(): Flow<Unit> = flow {
+    override suspend fun GuathLogout(): Flow<Unit> =
         performApiRequest { authService.gAuthLogout() }
-    }
 }

--- a/data/src/main/java/com/chobo/data/remote/datasource/auth/RemoteAuthDataSourceImpl.kt
+++ b/data/src/main/java/com/chobo/data/remote/datasource/auth/RemoteAuthDataSourceImpl.kt
@@ -3,27 +3,19 @@ package com.chobo.data.remote.datasource.auth
 import com.chobo.data.remote.api.AuthAPI
 import com.chobo.data.remote.dto.auth.request.GAuthLoginRequestBody
 import com.chobo.data.remote.dto.auth.response.GAuthLoginResponse
-import com.chobo.data.util.MindWayAPIHandler
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.*
+import com.chobo.data.util.performApiRequest
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
 class RemoteAuthDataSourceImpl @Inject constructor(
     private val authService: AuthAPI
 ) : RemoteAuthDataSource {
     override suspend fun GuauthLogin(body: GAuthLoginRequestBody): Flow<GAuthLoginResponse> = flow {
-        emit(
-            MindWayAPIHandler<GAuthLoginResponse>()
-                .httpRequest { authService.gAuthLogin(body = body) }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+        performApiRequest { authService.gAuthLogin(body = body) }
+    }
 
     override suspend fun GuathLogout(): Flow<Unit> = flow {
-        emit(
-            MindWayAPIHandler<Unit>()
-                .httpRequest { authService.gAuthLogout() }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+        performApiRequest { authService.gAuthLogout() }
+    }
 }

--- a/data/src/main/java/com/chobo/data/remote/datasource/book/RemoteBookDataSourceImpl.kt
+++ b/data/src/main/java/com/chobo/data/remote/datasource/book/RemoteBookDataSourceImpl.kt
@@ -3,57 +3,32 @@ package com.chobo.data.remote.datasource.book
 import com.chobo.data.remote.api.BookAPI
 import com.chobo.data.remote.dto.book.request.BookRequestBody
 import com.chobo.data.remote.dto.book.response.BookListResponse
-import com.chobo.data.util.MindWayAPIHandler
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.*
+import com.chobo.data.util.performApiRequest
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
 class RemoteBookDataSourceImpl @Inject constructor(
-    private val bookAPI: BookAPI
+    private val bookService: BookAPI
 ) : RemoteBookDataSource {
     override suspend fun bookUpload(body: BookRequestBody): Flow<Unit> = flow {
-        emit(
-            MindWayAPIHandler<Unit>()
-                .httpRequest { bookAPI.bookUpload(body = body) }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+        performApiRequest { bookService.bookUpload(body = body) }
+    }
 
     override suspend fun bookListGet(): Flow<List<BookListResponse>> = flow {
-        emit(
-            MindWayAPIHandler<List<BookListResponse>>()
-                .httpRequest { bookAPI.bookListGet() }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+        performApiRequest { bookService.bookListGet() }
+    }
 
 
-    override suspend fun bookGetById(
-        bookId: Long
-    ): Flow<BookRequestBody> = flow {
-        emit(
-            MindWayAPIHandler<BookRequestBody>()
-                .httpRequest { bookAPI.bookGetById(bookId = bookId) }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+    override suspend fun bookGetById(bookId: Long): Flow<BookRequestBody> = flow {
+        performApiRequest { bookService.bookGetById(bookId = bookId) }
+    }
 
-    override suspend fun bookModify(
-        body: BookRequestBody,
-        bookId: Long
-    ): Flow<Unit> = flow {
-        emit(
-            MindWayAPIHandler<Unit>()
-                .httpRequest { bookAPI.bookModify(body = body, bookId = bookId) }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+    override suspend fun bookModify(body: BookRequestBody, bookId: Long): Flow<Unit> = flow {
+        performApiRequest { bookService.bookModify(body = body, bookId = bookId) }
+    }
 
     override suspend fun bookDeleteById(bookId: Long): Flow<Unit> = flow {
-        emit(
-            MindWayAPIHandler<Unit>()
-                .httpRequest { bookAPI.bookDeleteById(bookId = bookId) }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+        performApiRequest { bookService.bookDeleteById(bookId = bookId) }
+    }
 }

--- a/data/src/main/java/com/chobo/data/remote/datasource/book/RemoteBookDataSourceImpl.kt
+++ b/data/src/main/java/com/chobo/data/remote/datasource/book/RemoteBookDataSourceImpl.kt
@@ -20,15 +20,12 @@ class RemoteBookDataSourceImpl @Inject constructor(
     }
 
 
-    override suspend fun bookGetById(bookId: Long): Flow<BookRequestBody> = flow {
+    override suspend fun bookGetById(bookId: Long): Flow<BookRequestBody> =
         performApiRequest { bookService.bookGetById(bookId = bookId) }
-    }
 
-    override suspend fun bookModify(body: BookRequestBody, bookId: Long): Flow<Unit> = flow {
+    override suspend fun bookModify(body: BookRequestBody, bookId: Long): Flow<Unit> =
         performApiRequest { bookService.bookModify(body = body, bookId = bookId) }
-    }
 
-    override suspend fun bookDeleteById(bookId: Long): Flow<Unit> = flow {
+    override suspend fun bookDeleteById(bookId: Long): Flow<Unit> =
         performApiRequest { bookService.bookDeleteById(bookId = bookId) }
-    }
 }

--- a/data/src/main/java/com/chobo/data/remote/datasource/event/RemoteEventDataSourceImpl.kt
+++ b/data/src/main/java/com/chobo/data/remote/datasource/event/RemoteEventDataSourceImpl.kt
@@ -5,17 +5,14 @@ import com.chobo.data.remote.dto.event.response.GetDetailEventResponse
 import com.chobo.data.remote.dto.event.response.GetEventListResponse
 import com.chobo.data.util.performApiRequest
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
 class RemoteEventDataSourceImpl @Inject constructor(
     private val eventService: EventAPI
 ): RemoteEventDataSource {
-    override suspend fun getEventList(status: String): Flow<List<GetEventListResponse>> = flow {
+    override suspend fun getEventList(status: String): Flow<List<GetEventListResponse>> =
         performApiRequest { eventService.getEventList(status = status) }
-    }
 
-    override suspend fun getDetailEvent(eventId: Long): Flow<GetDetailEventResponse> = flow {
+    override suspend fun getDetailEvent(eventId: Long): Flow<GetDetailEventResponse> =
         performApiRequest { eventService.getDetailEvent(eventId = eventId) }
-    }
 }

--- a/data/src/main/java/com/chobo/data/remote/datasource/event/RemoteEventDataSourceImpl.kt
+++ b/data/src/main/java/com/chobo/data/remote/datasource/event/RemoteEventDataSourceImpl.kt
@@ -3,37 +3,19 @@ package com.chobo.data.remote.datasource.event
 import com.chobo.data.remote.api.EventAPI
 import com.chobo.data.remote.dto.event.response.GetDetailEventResponse
 import com.chobo.data.remote.dto.event.response.GetEventListResponse
-import com.chobo.data.util.MindWayAPIHandler
-import kotlinx.coroutines.Dispatchers
+import com.chobo.data.util.performApiRequest
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.flowOn
 import javax.inject.Inject
 
 class RemoteEventDataSourceImpl @Inject constructor(
     private val eventService: EventAPI
 ): RemoteEventDataSource {
     override suspend fun getEventList(status: String): Flow<List<GetEventListResponse>> = flow {
-        emit(
-            MindWayAPIHandler<List<GetEventListResponse>>()
-                .httpRequest {
-                    eventService.getEventList(
-                        status = status
-                    )
-                }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+        performApiRequest { eventService.getEventList(status = status) }
+    }
 
     override suspend fun getDetailEvent(eventId: Long): Flow<GetDetailEventResponse> = flow {
-        emit(
-            MindWayAPIHandler<GetDetailEventResponse>()
-                .httpRequest {
-                    eventService.getDetailEvent(
-                        eventId = eventId
-                    )
-                }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+        performApiRequest { eventService.getDetailEvent(eventId = eventId) }
+    }
 }

--- a/data/src/main/java/com/chobo/data/remote/datasource/goal/RemoteGoalDataSourceImpl.kt
+++ b/data/src/main/java/com/chobo/data/remote/datasource/goal/RemoteGoalDataSourceImpl.kt
@@ -5,17 +5,14 @@ import com.chobo.data.remote.dto.goal.request.GoalRequestBodyPost
 import com.chobo.data.remote.dto.goal.response.GoalWeekendResponse
 import com.chobo.data.util.performApiRequest
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
 class RemoteGoalDataSourceImpl @Inject constructor(
     private val goalService: GoalAPI
 ) : RemoteGoalDataSource {
-    override suspend fun postGoalRequest(body: GoalRequestBodyPost): Flow<Unit> = flow {
+    override suspend fun postGoalRequest(body: GoalRequestBodyPost): Flow<Unit> =
         performApiRequest { goalService.postGoal(body = body) }
-    }
 
-    override suspend fun getWeekendGoalResponse(): Flow<GoalWeekendResponse> = flow {
+    override suspend fun getWeekendGoalResponse(): Flow<GoalWeekendResponse> =
         performApiRequest { goalService.getWeekendGoal() }
-    }
 }

--- a/data/src/main/java/com/chobo/data/remote/datasource/goal/RemoteGoalDataSourceImpl.kt
+++ b/data/src/main/java/com/chobo/data/remote/datasource/goal/RemoteGoalDataSourceImpl.kt
@@ -3,33 +3,19 @@ package com.chobo.data.remote.datasource.goal
 import com.chobo.data.remote.api.GoalAPI
 import com.chobo.data.remote.dto.goal.request.GoalRequestBodyPost
 import com.chobo.data.remote.dto.goal.response.GoalWeekendResponse
-import com.chobo.data.util.MindWayAPIHandler
-import kotlinx.coroutines.Dispatchers
+import com.chobo.data.util.performApiRequest
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.flowOn
 import javax.inject.Inject
 
 class RemoteGoalDataSourceImpl @Inject constructor(
     private val goalService: GoalAPI
 ) : RemoteGoalDataSource {
     override suspend fun postGoalRequest(body: GoalRequestBodyPost): Flow<Unit> = flow {
-        emit(
-            MindWayAPIHandler<Unit>()
-                .httpRequest {
-                    goalService.postGoal(body = body)
-                }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+        performApiRequest { goalService.postGoal(body = body) }
+    }
 
     override suspend fun getWeekendGoalResponse(): Flow<GoalWeekendResponse> = flow {
-        emit(
-            MindWayAPIHandler<GoalWeekendResponse>()
-                .httpRequest {
-                    goalService.getWeekendGoal()
-                }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+        performApiRequest { goalService.getWeekendGoal() }
+    }
 }

--- a/data/src/main/java/com/chobo/data/remote/datasource/my/RemoteMyDataSourceImpl.kt
+++ b/data/src/main/java/com/chobo/data/remote/datasource/my/RemoteMyDataSourceImpl.kt
@@ -5,17 +5,14 @@ import com.chobo.data.remote.dto.my_response.MyBookListResponse
 import com.chobo.data.remote.dto.my_response.MyDataResponse
 import com.chobo.data.util.performApiRequest
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
 class RemoteMyDataSourceImpl @Inject constructor(
     private val myService: MyAPI,
 ) : RemoteMyDataSource {
-    override suspend fun getMyInformation(): Flow<MyDataResponse> = flow {
+    override suspend fun getMyInformation(): Flow<MyDataResponse> =
         performApiRequest { myService.myInformationGet() }
-    }
 
-    override suspend fun getMyBookList(): Flow<List<MyBookListResponse>> = flow {
+    override suspend fun getMyBookList(): Flow<List<MyBookListResponse>> =
         performApiRequest { myService.myBookListGet() }
-    }
 }

--- a/data/src/main/java/com/chobo/data/remote/datasource/my/RemoteMyDataSourceImpl.kt
+++ b/data/src/main/java/com/chobo/data/remote/datasource/my/RemoteMyDataSourceImpl.kt
@@ -3,33 +3,19 @@ package com.chobo.data.remote.datasource.my
 import com.chobo.data.remote.api.MyAPI
 import com.chobo.data.remote.dto.my_response.MyBookListResponse
 import com.chobo.data.remote.dto.my_response.MyDataResponse
-import com.chobo.data.util.MindWayAPIHandler
-import kotlinx.coroutines.Dispatchers
+import com.chobo.data.util.performApiRequest
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.flowOn
 import javax.inject.Inject
 
 class RemoteMyDataSourceImpl @Inject constructor(
-    private val myAPI: MyAPI,
+    private val myService: MyAPI,
 ) : RemoteMyDataSource {
     override suspend fun getMyInformation(): Flow<MyDataResponse> = flow {
-        emit(
-            MindWayAPIHandler<MyDataResponse>()
-                .httpRequest {
-                    myAPI.myInformationGet()
-                }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+        performApiRequest { myService.myInformationGet() }
+    }
 
     override suspend fun getMyBookList(): Flow<List<MyBookListResponse>> = flow {
-        emit(
-            MindWayAPIHandler<List<MyBookListResponse>>()
-                .httpRequest {
-                    myAPI.myBookListGet()
-                }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+        performApiRequest { myService.myBookListGet() }
+    }
 }

--- a/data/src/main/java/com/chobo/data/remote/datasource/notice/RemoteNoticeDataSourceImpl.kt
+++ b/data/src/main/java/com/chobo/data/remote/datasource/notice/RemoteNoticeDataSourceImpl.kt
@@ -2,19 +2,15 @@ package com.chobo.data.remote.datasource.notice
 
 import com.chobo.data.remote.api.NoticeAPI
 import com.chobo.data.remote.dto.notice.NoticeAll
-import com.chobo.data.util.MindWayAPIHandler
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.*
+import com.chobo.data.util.performApiRequest
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
 class RemoteNoticeDataSourceImpl @Inject constructor(
-    private val noticeAPI: NoticeAPI
+    private val noticeService: NoticeAPI
 ) : RemoteNoticeDataSource {
     override suspend fun bookGet(): Flow<NoticeAll> = flow {
-        emit(
-            MindWayAPIHandler<NoticeAll>()
-                .httpRequest { noticeAPI.noticeGet() }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+        performApiRequest { noticeService.noticeGet() }
+    }
 }

--- a/data/src/main/java/com/chobo/data/remote/datasource/notice/RemoteNoticeDataSourceImpl.kt
+++ b/data/src/main/java/com/chobo/data/remote/datasource/notice/RemoteNoticeDataSourceImpl.kt
@@ -4,13 +4,11 @@ import com.chobo.data.remote.api.NoticeAPI
 import com.chobo.data.remote.dto.notice.NoticeAll
 import com.chobo.data.util.performApiRequest
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
 class RemoteNoticeDataSourceImpl @Inject constructor(
     private val noticeService: NoticeAPI
 ) : RemoteNoticeDataSource {
-    override suspend fun bookGet(): Flow<NoticeAll> = flow {
+    override suspend fun bookGet(): Flow<NoticeAll> =
         performApiRequest { noticeService.noticeGet() }
-    }
 }

--- a/data/src/main/java/com/chobo/data/remote/datasource/order/RemoteOrderDataSourceImpl.kt
+++ b/data/src/main/java/com/chobo/data/remote/datasource/order/RemoteOrderDataSourceImpl.kt
@@ -5,21 +5,17 @@ import com.chobo.data.remote.dto.my_response.MyBookListResponse
 import com.chobo.data.remote.dto.order_request.OrderRequestBody
 import com.chobo.data.util.performApiRequest
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
 class RemoteOrderDataSourceImpl @Inject constructor(
     private val orderService: OrderAPI,
 ) : RemoteOrderDataSource {
-    override suspend fun orderUpload(body: OrderRequestBody): Flow<Unit> = flow {
+    override suspend fun orderUpload(body: OrderRequestBody): Flow<Unit> =
         performApiRequest { orderService.orderUpload(body = body) }
-    }
 
-    override suspend fun orderModifyById(body: MyBookListResponse, orderId: Long): Flow<Unit> = flow {
+    override suspend fun orderModifyById(body: MyBookListResponse, orderId: Long): Flow<Unit> =
         performApiRequest { orderService.orderModifyById(body = body, orderId = orderId) }
-    }
 
-    override suspend fun orderDeleteById(orderId: Long): Flow<Unit> = flow {
+    override suspend fun orderDeleteById(orderId: Long): Flow<Unit> =
         performApiRequest { orderService.orderDeleteById(orderId = orderId) }
-    }
 }

--- a/data/src/main/java/com/chobo/data/remote/datasource/order/RemoteOrderDataSourceImpl.kt
+++ b/data/src/main/java/com/chobo/data/remote/datasource/order/RemoteOrderDataSourceImpl.kt
@@ -3,38 +3,23 @@ package com.chobo.data.remote.datasource.order
 import com.chobo.data.remote.api.OrderAPI
 import com.chobo.data.remote.dto.my_response.MyBookListResponse
 import com.chobo.data.remote.dto.order_request.OrderRequestBody
-import com.chobo.data.util.MindWayAPIHandler
-import kotlinx.coroutines.Dispatchers
+import com.chobo.data.util.performApiRequest
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.flowOn
 import javax.inject.Inject
 
 class RemoteOrderDataSourceImpl @Inject constructor(
-    private val orderAPI: OrderAPI,
+    private val orderService: OrderAPI,
 ) : RemoteOrderDataSource {
     override suspend fun orderUpload(body: OrderRequestBody): Flow<Unit> = flow {
-        emit(
-            MindWayAPIHandler<Unit>()
-                .httpRequest { orderAPI.orderUpload(body = body) }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+        performApiRequest { orderService.orderUpload(body = body) }
+    }
 
     override suspend fun orderModifyById(body: MyBookListResponse, orderId: Long): Flow<Unit> = flow {
-        emit(
-            MindWayAPIHandler<Unit>()
-                .httpRequest { orderAPI.orderModifyById(body = body, orderId = orderId) }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+        performApiRequest { orderService.orderModifyById(body = body, orderId = orderId) }
+    }
 
     override suspend fun orderDeleteById(orderId: Long): Flow<Unit> = flow {
-        emit(
-            MindWayAPIHandler<Unit>()
-                .httpRequest { orderAPI.orderDeleteById(orderId = orderId) }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
-
+        performApiRequest { orderService.orderDeleteById(orderId = orderId) }
+    }
 }

--- a/data/src/main/java/com/chobo/data/remote/datasource/rank/RemoteRankDataSourceImpl.kt
+++ b/data/src/main/java/com/chobo/data/remote/datasource/rank/RemoteRankDataSourceImpl.kt
@@ -2,21 +2,15 @@ package com.chobo.data.remote.datasource.rank
 
 import com.chobo.data.remote.api.RankApi
 import com.chobo.data.remote.dto.rank.RankResponse
-import com.chobo.data.util.MindWayAPIHandler
-import kotlinx.coroutines.Dispatchers
+import com.chobo.data.util.performApiRequest
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.flowOn
 import javax.inject.Inject
 
 class RemoteRankDataSourceImpl @Inject constructor(
-    private val rankApi: RankApi
+    private val rankService: RankApi
 ) : RemoteRankDataSource {
     override suspend fun rankGet(): Flow<List<RankResponse>> = flow {
-        emit(
-            MindWayAPIHandler<List<RankResponse>>()
-                .httpRequest { rankApi.rankGet() }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+        performApiRequest { rankService.rankGet() }
+    }
 }

--- a/data/src/main/java/com/chobo/data/remote/datasource/rank/RemoteRankDataSourceImpl.kt
+++ b/data/src/main/java/com/chobo/data/remote/datasource/rank/RemoteRankDataSourceImpl.kt
@@ -4,13 +4,11 @@ import com.chobo.data.remote.api.RankApi
 import com.chobo.data.remote.dto.rank.RankResponse
 import com.chobo.data.util.performApiRequest
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
 class RemoteRankDataSourceImpl @Inject constructor(
     private val rankService: RankApi
 ) : RemoteRankDataSource {
-    override suspend fun rankGet(): Flow<List<RankResponse>> = flow {
+    override suspend fun rankGet(): Flow<List<RankResponse>> =
         performApiRequest { rankService.rankGet() }
-    }
 }

--- a/data/src/main/java/com/chobo/data/remote/datasource/recommend/RemoteRecommendDataSourceImpl.kt
+++ b/data/src/main/java/com/chobo/data/remote/datasource/recommend/RemoteRecommendDataSourceImpl.kt
@@ -5,25 +5,20 @@ import com.chobo.data.remote.dto.recommend.request.RecommendAllRequest
 import com.chobo.data.remote.dto.recommend.response.GetRecommendBookListResponse
 import com.chobo.data.util.performApiRequest
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
 class RemoteRecommendDataSourceImpl @Inject constructor(
     private val recommendService: RecommendAPI
 ) : RemoteRecommendDataSource {
-    override suspend fun postRecommendBook(body: RecommendAllRequest, type: String): Flow<Unit> = flow {
+    override suspend fun postRecommendBook(body: RecommendAllRequest, type: String): Flow<Unit> =
         performApiRequest { recommendService.postRecommendBook(body = body, type = type) }
-    }
 
-    override suspend fun getRecommendBookList(type: String): Flow<List<GetRecommendBookListResponse>> = flow {
+    override suspend fun getRecommendBookList(type: String): Flow<List<GetRecommendBookListResponse>> =
         performApiRequest { recommendService.getRecommendBookList(type = type) }
-    }
 
-    override suspend fun patchRecommendBook(body: RecommendAllRequest, id: Long): Flow<Unit> = flow {
+    override suspend fun patchRecommendBook(body: RecommendAllRequest, id: Long): Flow<Unit> =
         performApiRequest { recommendService.patchRecommendBook(body = body, id = id) }
-    }
 
-    override suspend fun deleteRecommendBook(id: Long): Flow<Unit> = flow {
+    override suspend fun deleteRecommendBook(id: Long): Flow<Unit> =
         performApiRequest { recommendService.deleteRecommendBook(id = id) }
-    }
 }

--- a/data/src/main/java/com/chobo/data/remote/datasource/recommend/RemoteRecommendDataSourceImpl.kt
+++ b/data/src/main/java/com/chobo/data/remote/datasource/recommend/RemoteRecommendDataSourceImpl.kt
@@ -3,64 +3,27 @@ package com.chobo.data.remote.datasource.recommend
 import com.chobo.data.remote.api.RecommendAPI
 import com.chobo.data.remote.dto.recommend.request.RecommendAllRequest
 import com.chobo.data.remote.dto.recommend.response.GetRecommendBookListResponse
-import com.chobo.data.util.MindWayAPIHandler
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.*
+import com.chobo.data.util.performApiRequest
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
 class RemoteRecommendDataSourceImpl @Inject constructor(
     private val recommendService: RecommendAPI
 ) : RemoteRecommendDataSource {
-    override suspend fun postRecommendBook(
-        body: RecommendAllRequest,
-        type: String
-    ): Flow<Unit> = flow {
-        emit(
-            MindWayAPIHandler<Unit>()
-                .httpRequest {
-                    recommendService.postRecommendBook(
-                        body = body,
-                        type = type
-                    )
-                }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+    override suspend fun postRecommendBook(body: RecommendAllRequest, type: String): Flow<Unit> = flow {
+        performApiRequest { recommendService.postRecommendBook(body = body, type = type) }
+    }
 
     override suspend fun getRecommendBookList(type: String): Flow<List<GetRecommendBookListResponse>> = flow {
-        emit(
-            MindWayAPIHandler<List<GetRecommendBookListResponse>>()
-                .httpRequest {
-                    recommendService.getRecommendBookList(
-                        type = type
-                    )
-                }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+        performApiRequest { recommendService.getRecommendBookList(type = type) }
+    }
 
     override suspend fun patchRecommendBook(body: RecommendAllRequest, id: Long): Flow<Unit> = flow {
-        emit(
-            MindWayAPIHandler<Unit>()
-                .httpRequest {
-                    recommendService.patchRecommendBook(
-                        body = body,
-                        id = id
-                    )
-                }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+        performApiRequest { recommendService.patchRecommendBook(body = body, id = id) }
+    }
 
     override suspend fun deleteRecommendBook(id: Long): Flow<Unit> = flow {
-        emit(
-            MindWayAPIHandler<Unit>()
-                .httpRequest {
-                    recommendService.deleteRecommendBook(
-                        id = id
-                    )
-                }
-                .sendRequest()
-        )
-    }.flowOn(Dispatchers.IO)
+        performApiRequest { recommendService.deleteRecommendBook(id = id) }
+    }
 }

--- a/data/src/main/java/com/chobo/data/util/performApiRequest.kt
+++ b/data/src/main/java/com/chobo/data/util/performApiRequest.kt
@@ -1,0 +1,14 @@
+package com.chobo.data.util
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+
+internal inline fun <reified T> performApiRequest(crossinline apiCall: suspend () -> T): Flow<T> = flow {
+    emit(
+        MindWayAPIHandler<T>()
+            .httpRequest { apiCall() }
+            .sendRequest()
+    )
+}.flowOn(Dispatchers.IO)


### PR DESCRIPTION
## 📌 개요
- performApiRequest라는 플로우를 반환하는 함수를 만들어 datasource의 중복 로직의 문제점을 개선했습니다
- add performApiRequest
- apply performApiRequest

## 📸 구현 화면
- 스크린샷이 필요하다면 첨부해주세요.

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
- 참고할 사항이 있다면 적어주세요.
