### PR TITLE
🔀 :: (#417) - refactor homescreen

### DIFF
--- a/presentation/src/main/java/com/chobo/presentation/view/component/topBar/MindWayTopBar.kt
+++ b/presentation/src/main/java/com/chobo/presentation/view/component/topBar/MindWayTopBar.kt
@@ -33,12 +33,7 @@ fun MindWayTopAppBar(
             modifier = modifier
                 .fillMaxWidth()
                 .height(59.dp)
-                .padding(
-                    start = 24.dp,
-                    end = 24.dp,
-                    top = 20.dp,
-                    bottom = 12.dp
-                )
+                .padding(top = 20.dp,)
         ) {
             startIcon()
             Text(

--- a/presentation/src/main/java/com/chobo/presentation/view/main/component/HomeErrorNoticeCard.kt
+++ b/presentation/src/main/java/com/chobo/presentation/view/main/component/HomeErrorNoticeCard.kt
@@ -1,0 +1,57 @@
+package com.chobo.presentation.view.main.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.chobo.presentation.view.theme.MindWayAndroidTheme
+
+@Composable
+fun HomeErrorNoticeCard(
+    modifier: Modifier = Modifier,
+    text: String
+) {
+    MindWayAndroidTheme { colors, typography ->
+        Row(
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = modifier
+                .fillMaxWidth()
+                .shadow(
+                    elevation = 20.dp,
+                    spotColor = colors.CardShadow,
+                    ambientColor = colors.CardShadow
+                )
+                .background(
+                    color = colors.WHITE,
+                    shape = RoundedCornerShape(size = 8.dp)
+                )
+                .padding(horizontal = 12.dp)) {
+            Text(
+                modifier = modifier.padding(vertical = 36.5.dp),
+                text = text,
+                style = typography.bodySmall,
+                fontWeight = FontWeight.SemiBold,
+                color = colors.GRAY400,
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun Pre() {
+    HomeErrorNoticeCard(
+        text = "통신 원활 (x)"
+    )
+}

--- a/presentation/src/main/java/com/chobo/presentation/view/main/component/HomeNoticeCard.kt
+++ b/presentation/src/main/java/com/chobo/presentation/view/main/component/HomeNoticeCard.kt
@@ -5,9 +5,8 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -38,6 +37,7 @@ fun HomeNoticeCard(
             horizontalArrangement = Arrangement.spacedBy(20.dp, Alignment.Start),
             verticalAlignment = Alignment.CenterVertically,
             modifier = modifier
+                .fillMaxWidth()
                 .background(
                     color = colors.GRAY100,
                     shape = RoundedCornerShape(size = 8.dp)
@@ -54,12 +54,14 @@ fun HomeNoticeCard(
                 horizontalAlignment = Alignment.Start,
             ) {
                 Text(
+                    modifier = modifier.padding(top = 18.5.dp),
                     text = noticeAllModel.title,
                     style = typography.bodyMedium,
                     fontWeight = FontWeight.SemiBold,
                     color = colors.Black,
                 )
                 Text(
+                    modifier = modifier.padding(bottom = 18.5.dp),
                     text = noticeAllModel.content,
                     style = TextStyle(
                         fontSize = 12.sp,
@@ -78,9 +80,6 @@ fun HomeNoticeCard(
 @Composable
 fun HomeNoticeCardPreview() {
     HomeNoticeCard(
-        modifier = Modifier
-            .width(312.dp)
-            .height(100.dp),
         noticeAllModel = NoticeAllModel(title = "제목제목제목제목", content = "내용")
     )
 }

--- a/presentation/src/main/java/com/chobo/presentation/view/main/screen/HomeScreen.kt
+++ b/presentation/src/main/java/com/chobo/presentation/view/main/screen/HomeScreen.kt
@@ -140,7 +140,8 @@ internal fun HomeScreen(
 @Preview(showBackground = true)
 @Composable
 fun HomeScreenPreview() {
-    HomeScreen(getWeekendGoalUIState = GetWeekendGoalUiState.Loading, noticeGetUiState = NoticeGetUiState.Loading, getRankUIState = GetRankUiState.Loading) {
-        
-    }
+    HomeScreen(
+        getWeekendGoalUIState = GetWeekendGoalUiState.Loading,
+        noticeGetUiState = NoticeGetUiState.Loading,
+        getRankUIState = GetRankUiState.Loading) {}
 }

--- a/presentation/src/main/java/com/chobo/presentation/view/main/screen/HomeScreen.kt
+++ b/presentation/src/main/java/com/chobo/presentation/view/main/screen/HomeScreen.kt
@@ -20,6 +20,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.chobo.presentation.view.component.icon.LogoIcon
 import com.chobo.presentation.view.component.topBar.MindWayTopAppBar
+import com.chobo.presentation.view.main.component.HomeErrorNoticeCard
 import com.chobo.presentation.view.main.component.HomeGoalReadingChart
 import com.chobo.presentation.view.main.component.HomeNoticeCard
 import com.chobo.presentation.view.main.component.HomeReadersOfTheMonthChart
@@ -65,7 +66,6 @@ internal fun HomeScreen(
     navigateToGoalReading: () -> Unit,
 ) {
     MindWayAndroidTheme { colors, _ ->
-        MindWayTopAppBar(startIcon = { LogoIcon() })
         Column(
             verticalArrangement = Arrangement.spacedBy(20.dp, Alignment.Top),
             horizontalAlignment = Alignment.CenterHorizontally,
@@ -74,6 +74,7 @@ internal fun HomeScreen(
                 .fillMaxSize()
                 .padding(horizontal = 24.dp)
         ) {
+            MindWayTopAppBar(startIcon = { LogoIcon() })
             when (noticeGetUiState) {
                 is NoticeGetUiState.Success -> {
                     HomeNoticeCard(
@@ -83,8 +84,12 @@ internal fun HomeScreen(
                             .fillMaxWidth(),
                     )
                 }
-
-                else -> Unit
+                is NoticeGetUiState.Loading -> {
+                    HomeErrorNoticeCard(text = "데이터를 불러오는 중..")
+                }
+                is NoticeGetUiState.Fail -> {
+                    HomeErrorNoticeCard(text = "통신이 원활하지 않습니다..")
+                }
             }
             when (getWeekendGoalUIState) {
                 is GetWeekendGoalUiState.Success -> {
@@ -135,7 +140,7 @@ internal fun HomeScreen(
 @Preview(showBackground = true)
 @Composable
 fun HomeScreenPreview() {
-    HomeRoute(
-        navigateToGoalReading = { },
-    )
+    HomeScreen(getWeekendGoalUIState = GetWeekendGoalUiState.Loading, noticeGetUiState = NoticeGetUiState.Loading, getRankUIState = GetRankUiState.Loading) {
+        
+    }
 }


### PR DESCRIPTION
## 📌 개요
- 한 일을 간단하게 적어주세요.
   - HomeScreen을 리팩토링하였습니다
      - notice를 가져오는 부분에서 각 상태마다 나올 수 있는 ui 즉, 컴포넌트를 추가하였습니다
      - 불필요한 코드를 삭제하였습니다
      - 반응형 디자인을 하였습니다(notice card)
      - topBar가 Column 밖에 있어 다른 ui에 가려지던 문제를 Column의 안에 최상위에 두어 해결을 하였습니다
## 📸 구현 화면
- 스크린샷이 필요하다면 첨부해주세요.

<img width="248" alt="스크린샷 2024-08-26 오후 3 33 02" src="https://github.com/user-attachments/assets/38820135-afad-408f-9975-1846c4a04a28">


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
- 참고할 사항이 있다면 적어주세요.
   - 없음