### PR TITLE
🔀 :: (#448) - change swiperefreshindicator content color

### DIFF
--- a/presentation/src/main/java/com/chobo/presentation/view/book/screen/BookScreen.kt
+++ b/presentation/src/main/java/com/chobo/presentation/view/book/screen/BookScreen.kt
@@ -61,6 +61,7 @@ import com.chobo.presentation.viewModel.book.BookScreenViewModel
 import com.chobo.presentation.viewModel.book.uistate.GetRecommendBookUiState
 import com.chobo.presentation.viewModel.book.uistate.OrderUploadUiState
 import com.google.accompanist.swiperefresh.SwipeRefresh
+import com.google.accompanist.swiperefresh.SwipeRefreshIndicator
 import com.google.accompanist.swiperefresh.SwipeRefreshState
 import com.google.accompanist.swiperefresh.rememberSwipeRefreshState
 import kotlinx.collections.immutable.persistentListOf
@@ -131,6 +132,13 @@ internal fun BookScreen(
                 } else {
                     getNovelRecommendBook()
                 }
+            },
+            indicator = { state, refreshTrigger ->
+                SwipeRefreshIndicator(
+                    state = state,
+                    refreshTriggerDistance = refreshTrigger,
+                    contentColor = colors.MAIN
+                )
             }
         ) {
             Box(modifier = modifier.background(color = colors.WHITE)) {

--- a/presentation/src/main/java/com/chobo/presentation/view/event/screen/EventScreen.kt
+++ b/presentation/src/main/java/com/chobo/presentation/view/event/screen/EventScreen.kt
@@ -29,6 +29,7 @@ import com.chobo.presentation.view.theme.MindWayAndroidTheme
 import com.chobo.presentation.viewModel.event.EventViewModel
 import com.chobo.presentation.viewModel.event.uistate.GetEventListUiState
 import com.google.accompanist.swiperefresh.SwipeRefresh
+import com.google.accompanist.swiperefresh.SwipeRefreshIndicator
 import com.google.accompanist.swiperefresh.SwipeRefreshState
 import com.google.accompanist.swiperefresh.rememberSwipeRefreshState
 import kotlinx.coroutines.delay
@@ -87,6 +88,13 @@ internal fun EventScreen(
                     1 -> getEventNowList()
                     2 -> getEventPastList()
                 }
+            },
+            indicator = { state, refreshTrigger ->
+                SwipeRefreshIndicator(
+                    state = state,
+                    refreshTriggerDistance = refreshTrigger,
+                    contentColor = colors.MAIN
+                )
             }
         ) {
             Box(
@@ -184,7 +192,7 @@ fun EventScreenPre() {
         getEventPastList = { },
         getEventNowList = { },
         getEventNowListUiState = GetEventListUiState.Loading,
-        swipeRefreshState = rememberSwipeRefreshState(isRefreshing = false),
+        swipeRefreshState = rememberSwipeRefreshState(isRefreshing = true),
         getEventPastListUiState = GetEventListUiState.Loading,
         setSwipeRefreshLoading = { }
     )

--- a/presentation/src/main/java/com/chobo/presentation/view/main/screen/GoalReadingScreen.kt
+++ b/presentation/src/main/java/com/chobo/presentation/view/main/screen/GoalReadingScreen.kt
@@ -52,6 +52,7 @@ import com.chobo.presentation.viewModel.goal.GoalReadingViewModel
 import com.chobo.presentation.viewModel.goal.uistate.GetBookListUiState
 import com.chobo.presentation.viewModel.main.uistate.GetWeekendGoalUiState
 import com.google.accompanist.swiperefresh.SwipeRefresh
+import com.google.accompanist.swiperefresh.SwipeRefreshIndicator
 import com.google.accompanist.swiperefresh.SwipeRefreshState
 import com.google.accompanist.swiperefresh.rememberSwipeRefreshState
 import kotlinx.coroutines.CoroutineScope
@@ -186,6 +187,13 @@ internal fun GoalReadingScreen(
                     state = swipeRefreshState,
                     onRefresh = {
                         dataInit()
+                    },
+                    indicator = { state, refreshTigger ->
+                        SwipeRefreshIndicator(
+                            state = state,
+                            refreshTriggerDistance = refreshTigger,
+                            contentColor = colors.MAIN
+                        )
                     }
                 ) {
                     Box(modifier = Modifier.fillMaxSize()) {


### PR DESCRIPTION
## 📌 개요
- 한 일을 간단하게 적어주세요.
   - SwipeRefreshIndicator의 Content 색상을 MAIN으로 변경하였습니다.
   - refactor EventScreen
   - refactor BookScreen
   - refactor GoalReadingScreen
   
## 📸 구현 화면
- 스크린샷이 필요하다면 첨부해주세요.

- after
<img width="335" alt="스크린샷 2024-10-02 오전 9 29 32" src="https://github.com/user-attachments/assets/265765a3-c281-4fdf-9c24-3b6e3eab993c">

- before
<img width="332" alt="스크린샷 2024-10-02 오전 9 30 24" src="https://github.com/user-attachments/assets/a7ad0e91-2eba-4909-8196-811830d7d98e">

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
- 참고할 사항이 있다면 적어주세요.
